### PR TITLE
Set maximum `numpy` version to 1.19.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
         'dm_env',
         'grpcio',
         'mock',
-        'numpy>=1.10',
+        'numpy<1.20',
         'pexpect',
         'portpicker>=1.2.0',
         'protobuf>=2.6',


### PR DESCRIPTION
`numpy 1.20` requires Python 3.7 which is not common on Mac OS.