### PR TITLE
Create pyi files with builds of android_env

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ class _GenerateProtoFiles(setuptools.Command):
           '--proto_path={}'.format(grpc_protos_include),
           '--proto_path={}'.format(_ROOT_DIR),
           '--python_out={}'.format(_ROOT_DIR),
+          '--pyi_out={}'.format(_ROOT_DIR),
           '--grpc_python_out={}'.format(_ROOT_DIR),
           os.path.join(_ROOT_DIR, proto_path),
       ]


### PR DESCRIPTION
Its a simple addition, but with the added `--pyi_out` argument, the builds of the package come with type files that one can use to surf the codebase. In addition to the actual python protobuf files like `android_accessibility_window_info_pb2.py`:

```python
# -*- coding: utf-8 -*-
# Generated by the protocol buffer compiler.  DO NOT EDIT!
# NO CHECKED-IN PROTOBUF GENCODE
# source: android_env/proto/a11y/android_accessibility_window_info.proto
# Protobuf Python Version: 5.27.2
"""Generated protocol buffer code."""
from google.protobuf import descriptor as _descriptor
from google.protobuf import descriptor_pool as _descriptor_pool
from google.protobuf import runtime_version as _runtime_version
from google.protobuf import symbol_database as _symbol_database
from google.protobuf.internal import builder as _builder
_runtime_version.ValidateProtobufRuntimeVersion(
    _runtime_version.Domain.PUBLIC,
    5,
    27,
    2,
    '',
    'android_env/proto/a11y/android_accessibility_window_info.proto'
)
# @@protoc_insertion_point(imports)

_sym_db = _symbol_database.Default()


from android_env.proto.a11y import android_accessibility_tree_pb2 as android__env_dot_proto_dot_a11y_dot_android__accessibility__tree__pb2
from android_env.proto.a11y import rect_pb2 as android__env_dot_proto_dot_a11y_dot_rect__pb2


DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n>android_env/proto/a11y/android_accessibility_window_info.proto\x12\x0b\x61ndroid_env\x1a\x37\x61ndroid_env/proto/a11y/android_accessibility_tree.proto\x1a!android_env/proto/a11y/rect.proto\"\xa0\x04\n\x1e\x41ndroidAccessibilityWindowInfo\x12\x30\n\x10\x62ounds_in_screen\x18\x01 \x01(\x0b\x32\x16.android_env.ProtoRect\x12\x12\n\ndisplay_id\x18\x02 \x01(\x05\x12\n\n\x02id\x18\x03 \x01(\x05\x12\r\n\x05layer\x18\x04 \x01(\x05\x12\r\n\x05title\x18\x05 \x01(\t\x12K\n\x0bwindow_type\x18\x06 \x01(\x0e\x32\x36.android_env.AndroidAccessibilityWindowInfo.WindowType\x12 \n\x18is_accessibility_focused\x18\x07 \x01(\x08\x12\x11\n\tis_active\x18\x08 \x01(\x08\x12\x12\n\nis_focused\x18\t \x01(\x08\x12%\n\x1dis_in_picture_in_picture_mode\x18\n \x01(\x08\x12\x33\n\x04tree\x18\x0b \x01(\x0b\x32%.android_env.AndroidAccessibilityTree\"\x9b\x01\n\nWindowType\x12\x10\n\x0cUNKNOWN_TYPE\x10\x00\x12\x14\n\x10TYPE_APPLICATION\x10\x01\x12\x15\n\x11TYPE_INPUT_METHOD\x10\x02\x12\x0f\n\x0bTYPE_SYSTEM\x10\x03\x12\x1e\n\x1aTYPE_ACCESSIBILITY_OVERLAY\x10\x04\x12\x1d\n\x19TYPE_SPLIT_SCREEN_DIVIDER\x10\x05\x42\x30\n,com.google.androidenv.accessibilityforwarderP\x01\x62\x06proto3')

_globals = globals()
_builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'android_env.proto.a11y.android_accessibility_window_info_pb2', _globals)
if not _descriptor._USE_C_DESCRIPTORS:
  _globals['DESCRIPTOR']._loaded_options = None
  _globals['DESCRIPTOR']._serialized_options = b'\n,com.google.androidenv.accessibilityforwarderP\001'
  _globals['_ANDROIDACCESSIBILITYWINDOWINFO']._serialized_start=172
  _globals['_ANDROIDACCESSIBILITYWINDOWINFO']._serialized_end=716
  _globals['_ANDROIDACCESSIBILITYWINDOWINFO_WINDOWTYPE']._serialized_start=561
  _globals['_ANDROIDACCESSIBILITYWINDOWINFO_WINDOWTYPE']._serialized_end=716
# @@protoc_insertion_point(module_scope)

``` 


We obtain this slightly more readable `android_accessibility_window_info_pb2.pyi` file: 
```python
from android_env.proto.a11y import android_accessibility_tree_pb2 as _android_accessibility_tree_pb2
from android_env.proto.a11y import rect_pb2 as _rect_pb2
from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
from google.protobuf import descriptor as _descriptor
from google.protobuf import message as _message
from typing import ClassVar as _ClassVar, Mapping as _Mapping, Optional as _Optional, Union as _Union

DESCRIPTOR: _descriptor.FileDescriptor

class AndroidAccessibilityWindowInfo(_message.Message):
    __slots__ = ("bounds_in_screen", "display_id", "id", "layer", "title", "window_type", "is_accessibility_focused", "is_active", "is_focused", "is_in_picture_in_picture_mode", "tree")
    class WindowType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
        __slots__ = ()
        UNKNOWN_TYPE: _ClassVar[AndroidAccessibilityWindowInfo.WindowType]
        TYPE_APPLICATION: _ClassVar[AndroidAccessibilityWindowInfo.WindowType]
        TYPE_INPUT_METHOD: _ClassVar[AndroidAccessibilityWindowInfo.WindowType]
        TYPE_SYSTEM: _ClassVar[AndroidAccessibilityWindowInfo.WindowType]
        TYPE_ACCESSIBILITY_OVERLAY: _ClassVar[AndroidAccessibilityWindowInfo.WindowType]
        TYPE_SPLIT_SCREEN_DIVIDER: _ClassVar[AndroidAccessibilityWindowInfo.WindowType]
    UNKNOWN_TYPE: AndroidAccessibilityWindowInfo.WindowType
    TYPE_APPLICATION: AndroidAccessibilityWindowInfo.WindowType
    TYPE_INPUT_METHOD: AndroidAccessibilityWindowInfo.WindowType
    TYPE_SYSTEM: AndroidAccessibilityWindowInfo.WindowType
    TYPE_ACCESSIBILITY_OVERLAY: AndroidAccessibilityWindowInfo.WindowType
    TYPE_SPLIT_SCREEN_DIVIDER: AndroidAccessibilityWindowInfo.WindowType
    BOUNDS_IN_SCREEN_FIELD_NUMBER: _ClassVar[int]
    DISPLAY_ID_FIELD_NUMBER: _ClassVar[int]
    ID_FIELD_NUMBER: _ClassVar[int]
    LAYER_FIELD_NUMBER: _ClassVar[int]
    TITLE_FIELD_NUMBER: _ClassVar[int]
    WINDOW_TYPE_FIELD_NUMBER: _ClassVar[int]
    IS_ACCESSIBILITY_FOCUSED_FIELD_NUMBER: _ClassVar[int]
    IS_ACTIVE_FIELD_NUMBER: _ClassVar[int]
    IS_FOCUSED_FIELD_NUMBER: _ClassVar[int]
    IS_IN_PICTURE_IN_PICTURE_MODE_FIELD_NUMBER: _ClassVar[int]
    TREE_FIELD_NUMBER: _ClassVar[int]
    bounds_in_screen: _rect_pb2.ProtoRect
    display_id: int
    id: int
    layer: int
    title: str
    window_type: AndroidAccessibilityWindowInfo.WindowType
    is_accessibility_focused: bool
    is_active: bool
    is_focused: bool
    is_in_picture_in_picture_mode: bool
    tree: _android_accessibility_tree_pb2.AndroidAccessibilityTree
    def __init__(self, bounds_in_screen: _Optional[_Union[_rect_pb2.ProtoRect, _Mapping]] = ..., display_id: _Optional[int] = ..., id: _Optional[int] = ..., layer: _Optional[int] = ..., title: _Optional[str] = ..., window_type: _Optional[_Union[AndroidAccessibilityWindowInfo.WindowType, str]] = ..., is_accessibility_focused: bool = ..., is_active: bool = ..., is_focused: bool = ..., is_in_picture_in_picture_mode: bool = ..., tree: _Optional[_Union[_android_accessibility_tree_pb2.AndroidAccessibilityTree, _Mapping]] = ...) -> None: ...
```

