### PR TITLE
feat: Migrate GymWrapper from deprecated `gym` to `gymnasium`

### DIFF
--- a/android_env/wrappers/gym_wrapper.py
+++ b/android_env/wrappers/gym_wrapper.py
@@ -21,6 +21,7 @@ import dm_env
 from dm_env import specs
 import gymnasium as gym
 from gymnasium import spaces
+from gymnasium.core import RenderFrame
 import numpy as np
 
 
@@ -72,7 +73,7 @@ class GymInterfaceWrapper(gym.Env):
 
     raise ValueError('Unknown type for specs: {}'.format(spec))
 
-  def render(self) -> np.ndarray | None:
+  def render(self) -> RenderFrame | list[RenderFrame] | None:
     """Renders the environment."""
     if self.render_mode == 'rgb_array':
       if self._latest_observation is None:

--- a/android_env/wrappers/gym_wrapper.py
+++ b/android_env/wrappers/gym_wrapper.py
@@ -13,31 +13,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Wraps the AndroidEnv to expose an OpenAI Gym interface."""
+"""Wraps the AndroidEnv to expose a Gymnasium interface."""
 
 from typing import Any
 
-from android_env.wrappers import base_wrapper
 import dm_env
 from dm_env import specs
-import gym
-from gym import spaces
+import gymnasium as gym
+from gymnasium import spaces
 import numpy as np
 
 
 class GymInterfaceWrapper(gym.Env):
-  """AndroidEnv with OpenAI Gym interface."""
+  """AndroidEnv with Gymnasium interface."""
 
-  def __init__(self, env: dm_env.Environment):
+  metadata = {'render_modes': ['rgb_array']}
+
+  def __init__(self, env: dm_env.Environment, render_mode: str = 'rgb_array'):
     self._env = env
-    self.spec = None
+    self.render_mode = render_mode
     self.action_space = self._spec_to_space(self._env.action_spec())
     self.observation_space = self._spec_to_space(self._env.observation_spec())
-    self.metadata = {'render.modes': ['rgb_array']}
     self._latest_observation = None
 
   def _spec_to_space(self, spec: specs.Array) -> spaces.Space:
-    """Converts dm_env specs to OpenAI Gym spaces."""
+    """Converts dm_env specs to Gymnasium spaces."""
 
     if isinstance(spec, list):
       return spaces.Tuple([self._spec_to_space(s) for s in spec])
@@ -72,20 +72,23 @@ class GymInterfaceWrapper(gym.Env):
 
     raise ValueError('Unknown type for specs: {}'.format(spec))
 
-  def render(self, mode='rgb_array'):
+  def render(self) -> np.ndarray | None:
     """Renders the environment."""
-    if mode == 'rgb_array':
+    if self.render_mode == 'rgb_array':
       if self._latest_observation is None:
-        return
-
+        return None
       return self._latest_observation['pixels']
-    else:
-      raise ValueError('Only supported render mode is rgb_array.')
+    return None
 
-  def reset(self) -> np.ndarray:
+  def reset(
+      self, *, seed: int | None = None, options: dict[str, Any] | None = None
+  ) -> tuple[Any, dict[str, Any]]:
+    super().reset(seed=seed, options=options)
     self._latest_observation = None
     timestep = self._env.reset()
-    return timestep.observation
+    observation = timestep.observation
+    info = {'discount': timestep.discount}
+    return observation, info
 
   def step(self, action: Any) -> tuple[Any, ...]:
     """Take a step in the base environment."""
@@ -93,6 +96,15 @@ class GymInterfaceWrapper(gym.Env):
     observation = timestep.observation
     self._latest_observation = observation
     reward = timestep.reward
-    done = timestep.step_type == dm_env.StepType.LAST
+    # dm_env.termination() sets discount=0.0 (true episode end).
+    # dm_env.truncation() sets discount>0.0 (time limit or bad state).
+    terminated = (
+        timestep.step_type == dm_env.StepType.LAST
+        and timestep.discount == 0.0
+    )
+    truncated = (
+        timestep.step_type == dm_env.StepType.LAST
+        and timestep.discount != 0.0
+    )
     info = {'discount': timestep.discount}
-    return observation, reward, done, info
+    return observation, reward, terminated, truncated, info

--- a/android_env/wrappers/gym_wrapper_test.py
+++ b/android_env/wrappers/gym_wrapper_test.py
@@ -22,7 +22,7 @@ from android_env import env_interface
 from android_env.wrappers import gym_wrapper
 import dm_env
 from dm_env import specs
-from gym import spaces
+from gymnasium import spaces
 import numpy as np
 
 
@@ -68,12 +68,12 @@ class GymInterfaceWrapperTest(absltest.TestCase):
   def test_render(self):
     self._base_env.step.return_value = self._fake_ts
     _ = self._wrapped_env.step(action=np.zeros(shape=(1,)))
-    image = self._wrapped_env.render(mode='rgb_array')
+    image = self._wrapped_env.render()
     self.assertTrue(np.array_equal(image, np.ones(shape=(2, 3))))
 
-  def test_render_error(self):
-    with self.assertRaises(ValueError):
-      _ = self._wrapped_env.render(mode='human')
+  def test_render_none_before_step(self):
+    image = self._wrapped_env.render()
+    self.assertIsNone(image)
 
   def test_reset(self):
     self._base_env.reset.return_value = dm_env.TimeStep(
@@ -81,15 +81,39 @@ class GymInterfaceWrapperTest(absltest.TestCase):
         observation={'pixels': np.ones(shape=(2, 3))},
         reward=10.0,
         discount=1.0)
-    obs = self._wrapped_env.reset()
+    obs, info = self._wrapped_env.reset()
     self._base_env.reset.assert_called_once()
     self.assertTrue(np.array_equal(obs['pixels'], np.ones(shape=(2, 3))))
+    self.assertIn('discount', info)
 
-  def test_step(self):
+  def test_step_mid(self):
     self._base_env.step.return_value = self._fake_ts
-    obs, _, _, _ = self._wrapped_env.step(action=np.zeros(shape=(1,)))
+    obs, reward, terminated, truncated, info = self._wrapped_env.step(
+        action=np.zeros(shape=(1,)))
     self._base_env.step.assert_called_once()
     self.assertTrue(np.array_equal(obs['pixels'], np.ones(shape=(2, 3))))
+    self.assertEqual(reward, 10.0)
+    self.assertFalse(terminated)
+    self.assertFalse(truncated)
+    self.assertIn('discount', info)
+
+  def test_step_terminated(self):
+    ts = dm_env.termination(
+        reward=5.0, observation={'pixels': np.ones(shape=(2, 3))})
+    self._base_env.step.return_value = ts
+    _, _, terminated, truncated, _ = self._wrapped_env.step(
+        action=np.zeros(shape=(1,)))
+    self.assertTrue(terminated)
+    self.assertFalse(truncated)
+
+  def test_step_truncated(self):
+    ts = dm_env.truncation(
+        reward=3.0, observation={'pixels': np.ones(shape=(2, 3))})
+    self._base_env.step.return_value = ts
+    _, _, terminated, truncated, _ = self._wrapped_env.step(
+        action=np.zeros(shape=(1,)))
+    self.assertFalse(terminated)
+    self.assertTrue(truncated)
 
   def test_spec_to_space(self):
 

--- a/android_env/wrappers/gym_wrapper_test.py
+++ b/android_env/wrappers/gym_wrapper_test.py
@@ -69,6 +69,7 @@ class GymInterfaceWrapperTest(absltest.TestCase):
     self._base_env.step.return_value = self._fake_ts
     _ = self._wrapped_env.step(action=np.zeros(shape=(1,)))
     image = self._wrapped_env.render()
+    self.assertIsNotNone(image)
     self.assertTrue(np.array_equal(image, np.ones(shape=(2, 3))))
 
   def test_render_none_before_step(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,12 @@ dependencies = [
 
 [project.optional-dependencies]
 testing = [
-    "gym",
+    "gymnasium",
     "pillow",
     "pytype",
 ]
 acme = ["dm-acme"]
-gym = ["gym"]
+gym = ["gymnasium"]
 
 [project.urls]
 repository = "https://github.com/deepmind/android_env"


### PR DESCRIPTION
### **PR Description**
 fixes #376 
 
#### **Summary**
This pull request migrates the `GymInterfaceWrapper` from the deprecated OpenAI `gym` package to the modern `gymnasium` package. Gymnasium is now the industry standard for RL environments, and this update enables compatibility with modern reinforcement learning libraries (e.g., Stable-Baselines3, Acme, CleanRL).

---

#### **Proposed Changes**

##### **1. API Migration (`android_env/wrappers/gym_wrapper.py`)**
* Changed base class and imports to inherit from `gymnasium.Env`.
* Updated `reset()` to accept `*, seed: int | None = None, options: dict[str, Any] | None = None` and return the standard `(observation, info)` 2-tuple.
* Updated `step()` to return the standard 5-tuple `(observation, reward, terminated, truncated, info)`.
* Implemented correct semantic mapping from `dm_env.TimeStep`:
  * `terminated = True` if step type is `LAST` and `discount == 0.0` (indicates a true terminal state).
  * `truncated = True` if step type is `LAST` and `discount != 0.0` (indicates a time-limit truncation or boundary condition).
* Aligned `render()` logic with Gymnasium's parameter-less signature and `render_modes` configuration.

##### **2. Tests (`android_env/wrappers/gym_wrapper_test.py`)**
* Updated assertions to expect `(observation, info)` on `reset()`.
* Updated assertions to expect the new 5-tuple structure on `step()`.
* Added `test_step_terminated()` and `test_step_truncated()` tests to guarantee that termination and truncation conditions are correctly identified.
* Updated rendering tests to verify `self.render_mode`.

##### **3. Dependencies (`pyproject.toml`)**
* Swapped `gym` with `gymnasium` in both `testing` and `gym` optional dependency blocks.

---
