### PR TITLE
Add TrajectoryRecorderWrapper for recording episode trajectories to disk

### DIFF
--- a/android_env/wrappers/BUILD.bazel
+++ b/android_env/wrappers/BUILD.bazel
@@ -240,6 +240,32 @@ py_test(
 )
 
 py_library(
+    name = "trajectory_recorder_wrapper",
+    srcs = ["trajectory_recorder_wrapper.py"],
+    deps = [
+        ":base_wrapper",
+        "//android_env:env_interface",
+        "@pip//absl_py",
+        "@pip//dm_env",
+        "@pip//numpy",
+    ],
+)
+
+py_test(
+    name = "trajectory_recorder_wrapper_test",
+    srcs = ["trajectory_recorder_wrapper_test.py"],
+    legacy_create_init = False,
+    deps = [
+        ":trajectory_recorder_wrapper",
+        "//android_env:env_interface",
+        "//android_env/components:action_type",
+        "@pip//absl_py",
+        "@pip//dm_env",
+        "@pip//numpy",
+    ],
+)
+
+py_library(
     name = "tap_action_wrapper",
     srcs = ["tap_action_wrapper.py"],
     deps = [

--- a/android_env/wrappers/trajectory_recorder_wrapper.py
+++ b/android_env/wrappers/trajectory_recorder_wrapper.py
@@ -1,0 +1,127 @@
+# coding=utf-8
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Records full episode trajectories to disk."""
+
+import os
+import pathlib
+from typing import Any
+
+from absl import logging
+from android_env import env_interface
+from android_env.wrappers import base_wrapper
+import dm_env
+import numpy as np
+
+
+class TrajectoryRecorderWrapper(base_wrapper.BaseWrapper):
+  """Records (observation, action, reward, discount) trajectories to disk.
+
+  This wrapper does not alter observations, actions or rewards in any way; it
+  only observes them as they pass through and writes each completed episode to
+  its own compressed `.npz` file under `record_dir`. It is intended for
+  collecting human demonstrations (e.g. via `run_human_agent.py`) or agent
+  rollouts to be used downstream for imitation learning or reward-model
+  training, such as a data-collection step for RLHF. This wrapper itself does
+  not implement any training or learning algorithm.
+
+  Each `.npz` file contains one stacked array per observation field (keyed as
+  `observation.<name>`), one per action field (keyed as `action.<name>`), and
+  `step_type`, `reward`, `discount` arrays, all sharing the same leading
+  (time) dimension. The initial observation from `reset()` has no preceding
+  agent action, so it is paired with a zero-valued action.
+  """
+
+  def __init__(
+      self,
+      env: env_interface.AndroidEnvInterface,
+      record_dir: str | os.PathLike[str],
+      episode_prefix: str = 'episode',
+  ) -> None:
+    """Initializes this wrapper.
+
+    Args:
+      env: The environment to wrap.
+      record_dir: Directory where episode trajectories will be written. It
+        will be created if it does not already exist.
+      episode_prefix: Filename prefix used for each recorded episode.
+    """
+    super().__init__(env)
+    self._record_dir = pathlib.Path(record_dir)
+    self._record_dir.mkdir(parents=True, exist_ok=True)
+    self._episode_prefix = episode_prefix
+    self._episode_count = 0
+    self._steps: list[dict[str, Any]] = []
+    self._pending_action: dict[str, np.ndarray] | None = None
+
+  def _reset_state(self) -> None:
+    self._flush_episode()
+    self._pending_action = None
+
+  def _process_action(self, action: dict[str, np.ndarray]) -> Any:
+    self._pending_action = action
+    return action
+
+  def _process_timestep(self, timestep: dm_env.TimeStep) -> dm_env.TimeStep:
+    self._steps.append({
+        'step_type': np.int32(timestep.step_type),
+        'reward': np.float32(timestep.reward or 0.0),
+        'discount': np.float32(timestep.discount or 0.0),
+        'observation': timestep.observation,
+        'action': self._pending_action,
+    })
+    self._pending_action = None
+    if timestep.last():
+      self._flush_episode()
+    return timestep
+
+  def _zero_action(self) -> dict[str, np.ndarray]:
+    return {
+        name: np.zeros(spec.shape, dtype=spec.dtype)
+        for name, spec in self._env.action_spec().items()
+    }
+
+  def _flush_episode(self) -> None:
+    """Writes the currently buffered episode (if any) to disk."""
+    if not self._steps:
+      return
+
+    zero_action = self._zero_action()
+    arrays: dict[str, np.ndarray] = {
+        'step_type': np.stack([s['step_type'] for s in self._steps]),
+        'reward': np.stack([s['reward'] for s in self._steps]),
+        'discount': np.stack([s['discount'] for s in self._steps]),
+    }
+    for key in self._steps[0]['observation']:
+      arrays[f'observation.{key}'] = np.stack(
+          [s['observation'][key] for s in self._steps])
+    for key in zero_action:
+      arrays[f'action.{key}'] = np.stack(
+          [(s['action'] or zero_action)[key] for s in self._steps])
+
+    filename = (
+        self._record_dir
+        / f'{self._episode_prefix}_{self._episode_count:06d}.npz'
+    )
+    np.savez_compressed(filename, **arrays)
+    logging.info(
+        'Wrote %d-step trajectory to %s.', len(self._steps), filename)
+
+    self._episode_count += 1
+    self._steps = []
+
+  def close(self) -> None:
+    self._flush_episode()
+    super().close()

--- a/android_env/wrappers/trajectory_recorder_wrapper_test.py
+++ b/android_env/wrappers/trajectory_recorder_wrapper_test.py
@@ -1,0 +1,161 @@
+# coding=utf-8
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for android_env.wrappers.trajectory_recorder_wrapper."""
+
+import pathlib
+from unittest import mock
+
+from absl.testing import absltest
+from android_env import env_interface
+from android_env.components import action_type
+from android_env.wrappers import trajectory_recorder_wrapper
+import dm_env
+from dm_env import specs
+import numpy as np
+
+
+def _fake_env():
+  env = mock.create_autospec(env_interface.AndroidEnvInterface)
+  env.action_spec.return_value = {
+      'action_type':
+          specs.DiscreteArray(
+              num_values=len(action_type.ActionType), name='action_type'),
+      'touch_position':
+          specs.BoundedArray(
+              shape=(2,),
+              dtype=np.float32,
+              minimum=[0.0, 0.0],
+              maximum=[1.0, 1.0],
+              name='touch_position'),
+  }
+  return env
+
+
+def _timestep(step_type, reward=None, discount=None, pixel_value=0):
+  return dm_env.TimeStep(
+      step_type=step_type,
+      reward=reward,
+      discount=discount,
+      observation={
+          'pixels': np.full((4, 4, 3), pixel_value, dtype=np.uint8),
+      })
+
+
+def _action(x):
+  return {
+      'action_type': np.array(action_type.ActionType.TOUCH, dtype=np.int32),
+      'touch_position': np.array([x, x], dtype=np.float32),
+  }
+
+
+class TrajectoryRecorderWrapperTest(absltest.TestCase):
+
+  def test_records_full_episode_to_a_single_file(self):
+    record_dir = self.create_tempdir().full_path
+    env = _fake_env()
+    env.reset.return_value = _timestep(dm_env.StepType.FIRST)
+    env.step.side_effect = [
+        _timestep(dm_env.StepType.MID, reward=1.0, discount=1.0,
+                  pixel_value=1),
+        _timestep(dm_env.StepType.LAST, reward=2.0, discount=0.0,
+                  pixel_value=2),
+    ]
+
+    wrapper = trajectory_recorder_wrapper.TrajectoryRecorderWrapper(
+        env, record_dir=record_dir)
+    wrapper.reset()
+    wrapper.step(_action(0.25))
+    wrapper.step(_action(0.75))
+
+    files = sorted(pathlib.Path(record_dir).glob('*.npz'))
+    self.assertLen(files, 1)
+    self.assertEqual(files[0].name, 'episode_000000.npz')
+
+    with np.load(files[0]) as data:
+      self.assertEqual(data['step_type'].tolist(), [
+          dm_env.StepType.FIRST, dm_env.StepType.MID, dm_env.StepType.LAST
+      ])
+      np.testing.assert_allclose(data['reward'], [0.0, 1.0, 2.0])
+      np.testing.assert_allclose(data['discount'], [0.0, 1.0, 0.0])
+      self.assertEqual(data['observation.pixels'].shape, (3, 4, 4, 3))
+      np.testing.assert_array_equal(
+          data['observation.pixels'][:, 0, 0, 0], [0, 1, 2])
+
+      # The initial (reset) observation had no preceding action, so it should
+      # be padded with a zero-valued action.
+      self.assertEqual(data['action.touch_position'].shape, (3, 2))
+      np.testing.assert_allclose(data['action.touch_position'][0], [0.0, 0.0])
+      np.testing.assert_allclose(data['action.touch_position'][1], [0.25, 0.25])
+      np.testing.assert_allclose(data['action.touch_position'][2], [0.75, 0.75])
+
+  def test_separate_episodes_get_separate_files(self):
+    record_dir = self.create_tempdir().full_path
+    env = _fake_env()
+    env.reset.side_effect = [
+        _timestep(dm_env.StepType.FIRST),
+        _timestep(dm_env.StepType.FIRST),
+    ]
+    env.step.return_value = _timestep(dm_env.StepType.LAST, reward=1.0)
+
+    wrapper = trajectory_recorder_wrapper.TrajectoryRecorderWrapper(
+        env, record_dir=record_dir)
+    wrapper.reset()
+    wrapper.step(_action(0.1))
+    wrapper.reset()
+    wrapper.step(_action(0.2))
+
+    files = sorted(
+        f.name for f in pathlib.Path(record_dir).glob('*.npz'))
+    self.assertEqual(files, ['episode_000000.npz', 'episode_000001.npz'])
+
+  def test_close_flushes_incomplete_episode(self):
+    record_dir = self.create_tempdir().full_path
+    env = _fake_env()
+    env.reset.return_value = _timestep(dm_env.StepType.FIRST)
+    env.step.return_value = _timestep(dm_env.StepType.MID, reward=1.0)
+
+    wrapper = trajectory_recorder_wrapper.TrajectoryRecorderWrapper(
+        env, record_dir=record_dir)
+    wrapper.reset()
+    wrapper.step(_action(0.5))
+
+    self.assertEmpty(list(pathlib.Path(record_dir).glob('*.npz')))
+    wrapper.close()
+    self.assertLen(list(pathlib.Path(record_dir).glob('*.npz')), 1)
+    env.close.assert_called_once()
+
+  def test_no_file_written_when_no_steps_taken(self):
+    record_dir = self.create_tempdir().full_path
+    env = _fake_env()
+
+    wrapper = trajectory_recorder_wrapper.TrajectoryRecorderWrapper(
+        env, record_dir=record_dir)
+    wrapper.close()
+
+    self.assertEmpty(list(pathlib.Path(record_dir).glob('*.npz')))
+
+  def test_creates_record_dir_if_missing(self):
+    record_dir = pathlib.Path(self.create_tempdir().full_path) / 'nested'
+    env = _fake_env()
+
+    trajectory_recorder_wrapper.TrajectoryRecorderWrapper(
+        env, record_dir=record_dir)
+
+    self.assertTrue(record_dir.is_dir())
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/examples/run_human_agent.py
+++ b/examples/run_human_agent.py
@@ -25,6 +25,7 @@ from android_env import loader
 from android_env.components import action_type
 from android_env.components import config_classes
 from android_env.components import pixel_fns
+from android_env.wrappers import trajectory_recorder_wrapper
 import dm_env
 import numpy as np
 import pygame
@@ -41,6 +42,11 @@ flags.DEFINE_boolean('run_headless', True, 'Optionally turn off display.')
 
 # Environment args.
 flags.DEFINE_string('task_path', None, 'Path to task textproto file.')
+flags.DEFINE_string(
+    'record_dir', None,
+    'If set, records the full episode trajectories (observations, actions, '
+    'rewards) played by the human to this directory, e.g. for later use as '
+    'demonstrations for imitation learning or reward-model training.')
 
 # Pygame args.
 flags.DEFINE_list('screen_size', '480,720', 'Screen width, height in pixels.')
@@ -145,61 +151,74 @@ def main(_):
           ),
       ),
   )
-  with loader.load(config) as env:
+  with loader.load(config) as raw_env:
+    env = raw_env
+    if FLAGS.record_dir:
+      env = trajectory_recorder_wrapper.TrajectoryRecorderWrapper(
+          env, record_dir=FLAGS.record_dir)
 
-    # Reset environment.
-    first_timestep = env.reset()
-    orientation = int(np.argmax(first_timestep.observation['orientation']))
+    try:
+      # Reset environment.
+      first_timestep = env.reset()
+      orientation = int(
+          np.argmax(first_timestep.observation['orientation']))
 
-    # Create pygame canvas.
-    screen_size = list(map(int, FLAGS.screen_size))  # (W x H)
-    obs_shape = env.observation_spec()['pixels'].shape[:2]  # (H x W)
+      # Create pygame canvas.
+      screen_size = list(map(int, FLAGS.screen_size))  # (W x H)
+      obs_shape = env.observation_spec()['pixels'].shape[:2]  # (H x W)
 
-    if (orientation == 1 or orientation == 3):  # LANDSCAPE_90 | LANDSCAPE_270
-      screen_size = screen_size[::-1]
-      obs_shape = obs_shape[::-1]
+      if (orientation == 1 or orientation == 3):  # LANDSCAPE_90 | LANDSCAPE_270
+        screen_size = screen_size[::-1]
+        obs_shape = obs_shape[::-1]
 
-    screen = pygame.display.set_mode(screen_size)  # takes (W x H)
-    surface = pygame.Surface(obs_shape[::-1])  # takes (W x H)
+      screen = pygame.display.set_mode(screen_size)  # takes (W x H)
+      surface = pygame.Surface(obs_shape[::-1])  # takes (W x H)
 
-    # Start game loop.
-    prev_frame = time.time()
-    episode_return = 0
+      # Start game loop.
+      prev_frame = time.time()
+      episode_return = 0
 
-    while True:
-      if pygame.key.get_pressed()[pygame.K_ESCAPE]:
-        return
-
-      all_events = pygame.event.get()
-      for event in all_events:
-        if event.type == pygame.QUIT:
+      while True:
+        if pygame.key.get_pressed()[pygame.K_ESCAPE]:
           return
 
-      # Filter event queue for mouse click events.
-      mouse_click_events = [
-          event for event in all_events
-          if event.type in [pygame.MOUSEBUTTONDOWN, pygame.MOUSEBUTTONUP]
-      ]
+        all_events = pygame.event.get()
+        for event in all_events:
+          if event.type == pygame.QUIT:
+            return
 
-      # Process all mouse click events.
-      for event in mouse_click_events:
-        action = _get_action_from_event(event, screen, orientation)
+        # Filter event queue for mouse click events.
+        mouse_click_events = [
+            event for event in all_events
+            if event.type in [pygame.MOUSEBUTTONDOWN, pygame.MOUSEBUTTONUP]
+        ]
+
+        # Process all mouse click events.
+        for event in mouse_click_events:
+          action = _get_action_from_event(event, screen, orientation)
+          timestep = env.step(action)
+          episode_return = _accumulate_reward(timestep, episode_return)
+          _render_pygame_frame(surface, screen, orientation, timestep)
+
+        # Sample the current position of the mouse either way.
+        action = _get_action_from_mouse(screen, orientation)
         timestep = env.step(action)
         episode_return = _accumulate_reward(timestep, episode_return)
         _render_pygame_frame(surface, screen, orientation, timestep)
 
-      # Sample the current position of the mouse either way.
-      action = _get_action_from_mouse(screen, orientation)
-      timestep = env.step(action)
-      episode_return = _accumulate_reward(timestep, episode_return)
-      _render_pygame_frame(surface, screen, orientation, timestep)
-
-      # Limit framerate.
-      now = time.time()
-      frame_time = now - prev_frame
-      if frame_time < FLAGS.frame_rate:
-        time.sleep(FLAGS.frame_rate - frame_time)
-      prev_frame = now
+        # Limit framerate.
+        now = time.time()
+        frame_time = now - prev_frame
+        if frame_time < FLAGS.frame_rate:
+          time.sleep(FLAGS.frame_rate - frame_time)
+        prev_frame = now
+    finally:
+      # `env` may be a wrapper around `raw_env`; closing it explicitly here
+      # (rather than relying only on the `with` block above) ensures e.g. the
+      # trajectory recorder flushes its last, possibly incomplete, episode to
+      # disk. The subsequent `raw_env.close()` from the `with` block remains
+      # safe to call, since `close()` is idempotent.
+      env.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

There is currently no way in the library to persist an episode's
observations, actions, rewards, and discounts to disk. This adds a small,
self-contained wrapper that fills that gap:

- `TrajectoryRecorderWrapper` (`android_env/wrappers/trajectory_recorder_wrapper.py`):
  passes observations/actions/rewards through unchanged, and writes each
  completed episode to its own compressed `.npz` file under a configurable
  `record_dir`. Each file contains stacked arrays per observation field
  (`observation.<name>`), per action field (`action.<name>`), plus
  `step_type`, `reward`, and `discount`. The initial (post-reset) observation
  has no preceding action, so it's paired with a zero-valued action for
  alignment.
- Wires an optional `--record_dir` flag into `examples/run_human_agent.py` so
  human demonstration episodes can actually be captured with the existing
  human-agent tool, ensuring the wrapper's `close()` (which flushes any
  in-progress episode) runs on exit.

This is intentionally scoped to data collection only — no training/algorithm
code is included, consistent with the rest of the library. The intended use
case is collecting demonstrations/rollouts for downstream imitation learning
or reward-model training (e.g. as a first step toward RLHF-style pipelines
built on top of AndroidEnv), independent of any particular training
framework.

## Test plan

- [x] Added `trajectory_recorder_wrapper_test.py` covering: full-episode
      recording to a single file, zero-action padding of the initial
      observation, separate files per episode, flushing an incomplete
      episode on `close()`, no file written when no steps were taken, and
      creation of a missing `record_dir`.
- [x] Ran the new tests directly (`python -m android_env.wrappers.trajectory_recorder_wrapper_test`) — all 5 pass.
- [x] Ran existing `base_wrapper_test` and `last_action_wrapper_test` to confirm no regressions.
- [x] Added corresponding `py_library`/`py_test` targets to `android_env/wrappers/BUILD.bazel`.